### PR TITLE
Log frame counts

### DIFF
--- a/data/eigerfan/include/EigerFan.h
+++ b/data/eigerfan/include/EigerFan.h
@@ -66,6 +66,7 @@ private:
   std::string currentAcquisitionID;
   uint64_t lastFrameSent;
   uint64_t num_frames_sent;
+  std::vector<uint64_t> num_frames_consumed;
   int configuredOffset;
   int currentOffset;
   int numConnectedForwardingSockets;

--- a/data/eigerfan/src/EigerFan.cpp
+++ b/data/eigerfan/src/EigerFan.cpp
@@ -388,6 +388,8 @@ void EigerFan::HandleStreamMessage(zmq::message_t &message, boost::shared_ptr<zm
       } else if (htype.compare(END_HEADER_TYPE) == 0) {
         HandleEndOfSeriesMessage(socket);
         state = WAITING_STREAM;
+        LOG4CXX_INFO(log, "End of series message received after " + boost::lexical_cast<std::string>(num_frames_sent) \
+                + " frames sent");
       } else {
         LOG4CXX_ERROR(log, std::string("Unknown header type ").append(htype));
       }

--- a/data/eigerfan/src/EigerFan.cpp
+++ b/data/eigerfan/src/EigerFan.cpp
@@ -398,9 +398,13 @@ void EigerFan::HandleStreamMessage(zmq::message_t &message, boost::shared_ptr<zm
       } else if (htype.compare(END_HEADER_TYPE) == 0) {
         LOG4CXX_INFO(log, "End of series message received after " + boost::lexical_cast<std::string>(num_frames_sent) \
                 + " frames sent");
-        for(int j=0; j<num_frames_consumed.size(); j++)
-          LOG4CXX_INFO(log, "Consumer index " + boost::lexical_cast<std::string>(j) \
-                + " to consume " + boost::lexical_cast<std::string>(num_frames_consumed[j]) + " frames");
+        std::string consumer_frames;
+        for(int j=0; j<num_frames_consumed.size(); j++) {
+          consumer_frames +=
+                  boost::lexical_cast<std::string>(j) + ": " + \
+                          boost::lexical_cast<std::string>(num_frames_consumed[j]) + " ";
+        }
+        LOG4CXX_INFO(log, "Consumer frame counts " + consumer_frames);
         HandleEndOfSeriesMessage(socket);
         state = WAITING_STREAM;
       } else {

--- a/data/eigerfan/src/EigerFan.cpp
+++ b/data/eigerfan/src/EigerFan.cpp
@@ -374,8 +374,9 @@ void EigerFan::HandleStreamMessage(zmq::message_t &message, boost::shared_ptr<zm
         configuredOffset = 0;
         lastFrameSent = 0;
         num_frames_sent = 0;
-        for(int j=0; j<num_frames_consumed.size(); j++)
+        for(int j=0; j<num_frames_consumed.size(); j++) {
           num_frames_consumed[j] = 0;
+        }
         currentAcquisitionID = configuredAcquisitionID;
         // Handle Message
         HandleGlobalHeaderMessage(socket);
@@ -388,7 +389,12 @@ void EigerFan::HandleStreamMessage(zmq::message_t &message, boost::shared_ptr<zm
           lastFrameSent = frame;
         }
         num_frames_sent++;
-        num_frames_consumed[currentConsumerIndexToSendTo]++;
+        if (currentConsumerIndexToSendTo < num_frames_consumed.size()) {
+          num_frames_consumed[currentConsumerIndexToSendTo]++;
+        }
+        else {
+          LOG4CXX_WARN(log, "Error counting consumer frames for logging");
+        }
       } else if (htype.compare(END_HEADER_TYPE) == 0) {
         LOG4CXX_INFO(log, "End of series message received after " + boost::lexical_cast<std::string>(num_frames_sent) \
                 + " frames sent");

--- a/data/eigerfan/src/EigerFan.cpp
+++ b/data/eigerfan/src/EigerFan.cpp
@@ -393,7 +393,7 @@ void EigerFan::HandleStreamMessage(zmq::message_t &message, boost::shared_ptr<zm
         LOG4CXX_INFO(log, "End of series message received after " + boost::lexical_cast<std::string>(num_frames_sent) \
                 + " frames sent");
         for(int j=0; j<num_frames_consumed.size(); j++)
-          LOG4CXX_INFO(log, "Consumer index " + boost::lexical_cast<std::string>(currentConsumerIndexToSendTo) \
+          LOG4CXX_INFO(log, "Consumer index " + boost::lexical_cast<std::string>(j) \
                 + " to consume " + boost::lexical_cast<std::string>(num_frames_consumed[j]) + " frames");
         HandleEndOfSeriesMessage(socket);
         state = WAITING_STREAM;


### PR DESCRIPTION
A handful of additional statements in the logging to record the number of frames received from the Eiger and which consumers these are being sent to.