### PR TITLE
Update to use new MetaWriter base class

### DIFF
--- a/data/frameProcessor/src/EigerProcessPlugin.cpp
+++ b/data/frameProcessor/src/EigerProcessPlugin.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <EigerProcessPlugin.h>
+#include "Json.h"
 
 namespace FrameProcessor
 {
@@ -52,15 +53,11 @@ namespace FrameProcessor
     LOG4CXX_TRACE(logger_, "FrameHeader frame acquisition ID: " << hdrPtr->acquisitionID);
 
     // Create status message header
-    rapidjson::Document document;
-    document.SetObject();
 
     // Add Acquisition ID
     std::string acqIDString(hdrPtr->acquisitionID);
-    rapidjson::Value keyAcqID("acqID", document.GetAllocator());
-    rapidjson::Value valueAcqID;
-    valueAcqID.SetString(acqIDString.c_str(), acqIDString.length(), document.GetAllocator());
-    document.AddMember(keyAcqID, valueAcqID, document.GetAllocator());
+    OdinData::JsonDict json;
+    json.add("acqID", acqIDString);
 
     if (hdrPtr->messageType == Eiger::IMAGE_DATA) {
       frame->set_image_offset(sizeof(Eiger::FrameHeader));
@@ -82,184 +79,108 @@ namespace FrameProcessor
       frame->set_frame_number(hdrPtr->frame_number);
 
       // Add Frame number
-      rapidjson::Value keyFrame("frame", document.GetAllocator());
-      rapidjson::Value valueFrame(hdrPtr->frame_number);
-      document.AddMember(keyFrame, valueFrame, document.GetAllocator());
+      json.add("frame", hdrPtr->frame_number);
 
       // Add Series number
-      rapidjson::Value keySeries("series", document.GetAllocator());
-      rapidjson::Value valueSeries(hdrPtr->series);
-      document.AddMember(keySeries, valueSeries, document.GetAllocator());
+      json.add("series", hdrPtr->series);
 
       // Add Size
-      rapidjson::Value keySize("size", document.GetAllocator());
-      rapidjson::Value valueSize(hdrPtr->size_in_header);
-      document.AddMember(keySize, valueSize, document.GetAllocator());
+      json.add("size", hdrPtr->size_in_header);
 
       // Add Start Time
-      rapidjson::Value keyStart("start_time", document.GetAllocator());
-      rapidjson::Value valueStart(hdrPtr->startTime);
-      document.AddMember(keyStart, valueStart, document.GetAllocator());
+      json.add("start_time", hdrPtr->startTime);
 
       // Add Stop Time
-      rapidjson::Value keyStop("stop_time", document.GetAllocator());
-      rapidjson::Value valueStop(hdrPtr->stopTime);
-      document.AddMember(keyStop, valueStop, document.GetAllocator());
+      json.add("stop_time", hdrPtr->stopTime);
 
       // Add Real Time
-      rapidjson::Value keyReal("real_time", document.GetAllocator());
-      rapidjson::Value valueReal(hdrPtr->realTime);
-      document.AddMember(keyReal, valueReal, document.GetAllocator());
+      json.add("real_time", hdrPtr->realTime);
 
       // Add shape
-      rapidjson::Value keyShape("shape", document.GetAllocator());
-      rapidjson::Value valueShape;
-      valueShape.SetArray();
-      valueShape.PushBack(hdrPtr->shapeSizeX, document.GetAllocator());
-      valueShape.PushBack(hdrPtr->shapeSizeY, document.GetAllocator());
-      document.AddMember(keyShape, valueShape, document.GetAllocator());
+      std::vector<uint32_t> shape;
+      shape.push_back(hdrPtr->shapeSizeX);
+      shape.push_back(hdrPtr->shapeSizeY);
+      json.add("shape", shape);
 
       // Add data type
       std::string dataTypeString(hdrPtr->dataType);
-      rapidjson::Value keyType("type", document.GetAllocator());
-      rapidjson::Value valueType;
-      valueType.SetString(dataTypeString.c_str(), dataTypeString.length(), document.GetAllocator());
-      document.AddMember(keyType, valueType, document.GetAllocator());
+      json.add("type", dataTypeString);
 
       // Add encoding
       std::string encodingString(hdrPtr->encoding);
-      rapidjson::Value keyEncoding("encoding", document.GetAllocator());
-      rapidjson::Value valueEncoding;
-      valueEncoding.SetString(encodingString.c_str(), encodingString.length(), document.GetAllocator());
-      document.AddMember(keyEncoding, valueEncoding, document.GetAllocator());
+      json.add("encoding", encodingString);
 
       // Add hash
       std::string hashString(hdrPtr->hash);
-      rapidjson::Value keyHash("hash", document.GetAllocator());
-      rapidjson::Value valueHash;
-      valueHash.SetString(hashString.c_str(), hashString.length(), document.GetAllocator());
-      document.AddMember(keyHash, valueHash, document.GetAllocator());
+      json.add("hash", hashString);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-imagedata", buffer.GetString(), buffer.GetString());
+      publish_meta(get_name(), "eiger-imagedata", json.str(), json.str());
 
       this->push(frame);
     } else if (hdrPtr->messageType == Eiger::IMAGE_APPENDIX) {
       std::string dataString((static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size);
 
       // Add Frame number
-      rapidjson::Value keyFrame("frame", document.GetAllocator());
-      rapidjson::Value valueFrame(hdrPtr->frame_number);
-      document.AddMember(keyFrame, valueFrame, document.GetAllocator());
+      json.add("frame", hdrPtr->frame_number);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-imageappendix", dataString, buffer.GetString());
+      publish_meta(get_name(), "eiger-imageappendix", dataString, json.str());
     } else if (hdrPtr->messageType == Eiger::GLOBAL_HEADER_NONE) {
       // Add Series number
-      rapidjson::Value keySeries("series", document.GetAllocator());
-      rapidjson::Value valueSeries(hdrPtr->series);
-      document.AddMember(keySeries, valueSeries, document.GetAllocator());
+      json.add("series", hdrPtr->series);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-globalnone", buffer.GetString(), buffer.GetString());
+      publish_meta(get_name(), "eiger-globalnone", json.str(), json.str());
     } else if (hdrPtr->messageType == Eiger::GLOBAL_HEADER_CONFIG) {
       std::string dataString((static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size);
 
       // Add Series number
-      rapidjson::Value keySeries("series", document.GetAllocator());
-      rapidjson::Value valueSeries(hdrPtr->series);
-      document.AddMember(keySeries, valueSeries, document.GetAllocator());
+      json.add("series", hdrPtr->series);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-globalconfig", dataString, buffer.GetString());
+      publish_meta(get_name(), "eiger-globalconfig", dataString, json.str());
     } else if (hdrPtr->messageType == Eiger::GLOBAL_HEADER_FLATFIELD) {
       // Add shape
-      rapidjson::Value keyShape("shape", document.GetAllocator());
-      rapidjson::Value valueShape;
-      valueShape.SetArray();
-      valueShape.PushBack(hdrPtr->shapeSizeX, document.GetAllocator());
-      valueShape.PushBack(hdrPtr->shapeSizeY, document.GetAllocator());
-      document.AddMember(keyShape, valueShape, document.GetAllocator());
+      std::vector<uint32_t> shape;
+      shape.push_back(hdrPtr->shapeSizeX);
+      shape.push_back(hdrPtr->shapeSizeY);
+      json.add("shape", shape);
 
       // Add data type
-      rapidjson::Value keyType("type", document.GetAllocator());
-      rapidjson::Value valueType(hdrPtr->dataType);
-      document.AddMember(keyType, valueType, document.GetAllocator());
+      std::string dataTypeString(hdrPtr->dataType);
+      json.add("type", dataTypeString);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-globalflatfield", reinterpret_cast<const void*>(static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size, buffer.GetString());
+      publish_meta(get_name(), "eiger-globalflatfield", reinterpret_cast<const void*>(static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size, json.str());
     } else if (hdrPtr->messageType == Eiger::GLOBAL_HEADER_MASK) {
-      // Set shape
-      rapidjson::Value keyShape("shape", document.GetAllocator());
-      rapidjson::Value valueShape;
-      valueShape.SetArray();
-      valueShape.PushBack(hdrPtr->shapeSizeX, document.GetAllocator());
-      valueShape.PushBack(hdrPtr->shapeSizeY, document.GetAllocator());
-      document.AddMember(keyShape, valueShape, document.GetAllocator());
+      // Add shape
+      std::vector<uint32_t> shape;
+      shape.push_back(hdrPtr->shapeSizeX);
+      shape.push_back(hdrPtr->shapeSizeY);
+      json.add("shape", shape);
 
-      // Set data type
-      rapidjson::Value keyType("type", document.GetAllocator());
-      rapidjson::Value valueType(hdrPtr->dataType);
-      document.AddMember(keyType, valueType, document.GetAllocator());
+      // Add data type
+      std::string dataTypeString(hdrPtr->dataType);
+      json.add("type", dataTypeString);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-globalmask", reinterpret_cast<const void*>(static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size, buffer.GetString());
+      publish_meta(get_name(), "eiger-globalmask", reinterpret_cast<const void*>(static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size, json.str());
     } else if (hdrPtr->messageType == Eiger::GLOBAL_HEADER_COUNTRATE) {
-      // Set shape
-      rapidjson::Value keyShape("shape", document.GetAllocator());
-      rapidjson::Value valueShape;
-      valueShape.SetArray();
-      valueShape.PushBack(hdrPtr->shapeSizeX, document.GetAllocator());
-      valueShape.PushBack(hdrPtr->shapeSizeY, document.GetAllocator());
-      document.AddMember(keyShape, valueShape, document.GetAllocator());
+      // Add shape
+      std::vector<uint32_t> shape;
+      shape.push_back(hdrPtr->shapeSizeX);
+      shape.push_back(hdrPtr->shapeSizeY);
+      json.add("shape", shape);
 
-      // Set data type
-      rapidjson::Value keyType("type", document.GetAllocator());
-      rapidjson::Value valueType(hdrPtr->dataType);
-      document.AddMember(keyType, valueType, document.GetAllocator());
+      // Add data type
+      std::string dataTypeString(hdrPtr->dataType);
+      json.add("type", dataTypeString);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-globalcountrate", reinterpret_cast<const void*>(static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size, buffer.GetString());
+      publish_meta(get_name(), "eiger-globalcountrate", reinterpret_cast<const void*>(static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size, json.str());
     } else if (hdrPtr->messageType == Eiger::GLOBAL_HEADER_APPENDIX) {
       std::string dataString((static_cast<const char*>(frame->get_image_ptr())+sizeof(Eiger::FrameHeader)), hdrPtr->data_size);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-headerappendix", dataString, buffer.GetString());
+      publish_meta(get_name(), "eiger-headerappendix", dataString, json.str());
     } else if (hdrPtr->messageType == Eiger::END_OF_STREAM) {
       // Add Series number
-      rapidjson::Value keySeries("series", document.GetAllocator());
-      rapidjson::Value valueSeries(hdrPtr->series);
-      document.AddMember(keySeries, valueSeries, document.GetAllocator());
+      json.add("series", hdrPtr->series);
 
-      rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-      document.Accept(writer);
-
-      publish_meta(get_name(), "eiger-end", "", buffer.GetString());
+      publish_meta(get_name(), "eiger-end", "", json.str());
     }
   }
 

--- a/data/frameProcessor/src/EigerProcessPlugin.cpp
+++ b/data/frameProcessor/src/EigerProcessPlugin.cpp
@@ -250,7 +250,16 @@ namespace FrameProcessor
 
       publish_meta(get_name(), "eiger-headerappendix", dataString, buffer.GetString());
     } else if (hdrPtr->messageType == Eiger::END_OF_STREAM) {
-      // Do nothing with End of Stream message
+      // Add Series number
+      rapidjson::Value keySeries("series", document.GetAllocator());
+      rapidjson::Value valueSeries(hdrPtr->series);
+      document.AddMember(keySeries, valueSeries, document.GetAllocator());
+
+      rapidjson::StringBuffer buffer;
+      rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+      document.Accept(writer);
+
+      publish_meta(get_name(), "eiger-end", "", buffer.GetString());
     }
   }
 

--- a/data/frameSimulator/include/EigerFrameSimulatorOptions.h
+++ b/data/frameSimulator/include/EigerFrameSimulatorOptions.h
@@ -15,7 +15,7 @@ namespace FrameSimulator {
     static const FrameSimulatorOption<std::string> opt_filepattern("file-pattern", "File pattern", "streamfile");
     static const FrameSimulatorOption<int> opt_delay("delay-adjustment", "Delay adjustment", 70000);
     static const FrameSimulatorOption<bool> opt_stream("stream", "Stream mode", false);
-
+    static const FrameSimulatorOption<bool> opt_user_prompt("prompt", "User prompt delay enable", false);
 }
 
 #endif //FRAMESIMULATOR_EIGERFRAMESIMULATOROPTIONS_H

--- a/data/frameSimulator/include/EigerFrameSimulatorPlugin.h
+++ b/data/frameSimulator/include/EigerFrameSimulatorPlugin.h
@@ -56,7 +56,10 @@ namespace FrameSimulator {
         void sendEndOfSeries(zmq::socket_t& sender);
         void sendImageData(zmq::socket_t& sender, std::string file_pattern, int frames, int hertz);
         void SendFileMessage(zmq::socket_t &socket, std::string filePath, bool more);
+        std::string setMessageFrameNumber(std::string message, int frame_number);
+        void sendMessage(zmq::socket_t &socket, std::string message, bool more);
         std::string getSingleLineFromFile(std::string file);
+        void wait_for_interval(double interval);
 
         boost::optional<std::string> filepath;
         std::string filepattern;
@@ -64,6 +67,7 @@ namespace FrameSimulator {
         int delay_adjustment;
         std::vector<std::string> dest_ports;
         bool stream;
+        bool user_prompt;
 
     };
 
@@ -71,4 +75,4 @@ namespace FrameSimulator {
 
 }
 
-#endif 
+#endif

--- a/data/test/SendMetaControl.py
+++ b/data/test/SendMetaControl.py
@@ -24,7 +24,7 @@ def main():
     context = zmq.Context()
     ctrlSocket = context.socket(zmq.DEALER)
     ctrlSocket.connect("tcp://127.0.0.1:5659")
-    reply = json.dumps({'msg_type':'cmd', 'id':1, 'msg_val':'configure', 'params': {'output_dir':args.directory, 'acquisition_id':'test_1'}, 'timestamp':datetime.now().isoformat()})
+    reply = json.dumps({'msg_type':'cmd', 'id':1, 'msg_val':'configure', 'params': {'directory':args.directory, 'acquisition_id':'test_1'}, 'timestamp':datetime.now().isoformat()})
     ctrlSocket.send(reply)
 
 

--- a/data/test/system_test.sh
+++ b/data/test/system_test.sh
@@ -31,7 +31,7 @@ echo 'Starting Meta Listener'
 
 cd $metalistenerdir
 export PYTHONPATH=$eigerrootdir/data/tools/python/:$odinrootdir/tools/python/
-meta_writer -w metalistener.eiger_meta_writer.EigerMetaWriter -i tcp://127.0.0.1:5008 -d $outputdir &
+meta_writer -w metalistener.eiger_meta_writer.EigerMetaWriter --data-endpoints tcp://127.0.0.1:5008 &
 metalistener_pid=$!
 
 sleep 2

--- a/data/tools/python/metalistener/__init__.py
+++ b/data/tools/python/metalistener/__init__.py
@@ -1,0 +1,3 @@
+from eiger_meta_writer import EigerMetaWriter
+
+__all__ = ["EigerMetaWriter"]

--- a/data/tools/python/metalistener/eiger_meta_writer.py
+++ b/data/tools/python/metalistener/eiger_meta_writer.py
@@ -4,557 +4,143 @@ This module is a subclass of the odin_data MetaWriter and handles Eiger specific
 
 Matt Taylor, Diamond Light Source
 """
-import numpy as np
-import time
 import re
-import ast
+from json import loads
 
-from odin_data.meta_writer.meta_writer import MetaWriter
+import numpy as np
+
+from odin_data.meta_writer.meta_writer import MetaWriter, MESSAGE_TYPE_ID, FRAME
+from odin_data.meta_writer.hdf5dataset import Int64HDF5Dataset, StringHDF5Dataset
+from odin_data.util import construct_version_dict
 import _version as versioneer
 
-MAJOR_VER_REGEX = r"^([0-9]+)[\\.-].*|$"
-MINOR_VER_REGEX = r"^[0-9]+[\\.-]([0-9]+).*|$"
-PATCH_VER_REGEX = r"^[0-9]+[\\.-][0-9]+[\\.-]([0-9]+).|$"
+# Data message parameters
+START_TIME = "start_time"
+STOP_TIME = "stop_time"
+REAL_TIME = "real_time"
+SERIES = "series"
+SIZE = "size"
+HASH = "hash"
+ENCODING = "encoding"
+DATATYPE = "type"
+
 
 class EigerMetaWriter(MetaWriter):
-    """Eiger Meta Writer class.
+    """Implementation of MetaWriter that also handles Eiger meta messages"""
 
-    Eiger Detector Meta Writer writes Eiger meta data to disk
-    """
+    # Define Eiger-specific datasets
+    DETECTOR_DATASETS = [
+        Int64HDF5Dataset(START_TIME),
+        Int64HDF5Dataset(STOP_TIME),
+        Int64HDF5Dataset(REAL_TIME),
+        Int64HDF5Dataset(SERIES),
+        Int64HDF5Dataset(SIZE),
+        StringHDF5Dataset(HASH, length=32),
+        StringHDF5Dataset(ENCODING, length=10),
+        StringHDF5Dataset(DATATYPE, length=6),
+    ]
+    # Define parameters received on per frame meta message
+    DETECTOR_WRITE_FRAME_PARAMETERS = [
+        START_TIME,
+        STOP_TIME,
+        REAL_TIME,
+        SERIES,
+        SIZE,
+        HASH,
+        ENCODING,
+        DATATYPE,
+    ]
 
-    def __init__(self, logger, directory, acquisitionID):
-        """Initalise the EigerMetaWriter object.
+    def process_message(self, header, data):
+        """Process a message from a data socket
 
-        :param logger: Logger to use
-        :param directory: Directory to create the meta file in
-        :param acquisitionID: Acquisition ID of this acquisition
+        Check for Eiger-specific messages and pass anything else to base class
+
         """
-        super(EigerMetaWriter, self).__init__(logger, directory, acquisitionID)
+        message_handlers = {
+            "eiger-globalnone": self.handle_global_header_none,
+            "eiger-globalconfig": self.handle_global_header_config,
+            "eiger-globalflatfield": self.handle_flatfield_header,
+            "eiger-globalmask": self.handle_mask_header,
+            "eiger-globalcountrate": self.handle_countrate_header,
+            "eiger-headerappendix": self.handle_header_appendix,
+            "eiger-imagedata": self.handle_image_data,
+            "eiger-imageappendix": self.handle_image_appendix,
+            "eiger-end": self.handle_end,
+        }
 
-        self.add_dataset_definition("start_time", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-        self.add_dataset_definition("stop_time", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-        self.add_dataset_definition("real_time", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-        self.add_dataset_definition("frame", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-        self.add_dataset_definition("size", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-        self.add_dataset_definition("hash", (0,), maxshape=(None,), dtype='S32', fillvalue=None)
-        self.add_dataset_definition("encoding", (0,), maxshape=(None,), dtype='S10', fillvalue=None)
-        self.add_dataset_definition("datatype", (0,), maxshape=(None,), dtype='S6', fillvalue=None)
-        self.add_dataset_definition("frame_series", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-        self.add_dataset_definition("frame_written", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-        self.add_dataset_definition("offset_written", (0,), maxshape=(None,), dtype='int64', fillvalue=-1)
-
-        self._num_frame_offsets_written = 0
-        self._current_frame_count = 0
-        self._need_to_write_data = False
-        self._arrays_created = False
-        self._close_after_write = False
-        self._frame_offset_dict = {}
-        self._frame_data_dict = {}
-
-        self._series_created = False
-        self._config_created = False
-        self._flatfield_created = False
-        self._pixel_mask_created = False
-        self._countrate_created = False
-        self._global_appendix_created = False
-
-        self.start_new_acquisition()
-        
-    @staticmethod    
-    def get_version():
-      
-        version = versioneer.get_versions()["version"]
-        major_version = re.findall(MAJOR_VER_REGEX, version)[0]
-        minor_version = re.findall(MINOR_VER_REGEX, version)[0]
-        patch_version = re.findall(PATCH_VER_REGEX, version)[0]
-        short_version = major_version + "." + minor_version + "." + patch_version
-        
-        version_dict = {}
-        version_dict["full"] = version
-        version_dict["major"] = major_version
-        version_dict["minor"] = minor_version
-        version_dict["patch"] = patch_version
-        version_dict["short"] = short_version
-        return version_dict
-
-    def start_new_acquisition(self):
-        """Performs actions needed when the acquisition is started."""
-
-        self._frame_offset_dict.clear()
-        self._frame_data_dict.clear()
-
-        self._series_created = False
-        self._config_created = False
-        self._flatfield_created = False
-        self._pixel_mask_created = False
-        self._countrate_created = False
-        self._global_appendix_created = False
-
-        return
-
-    def handle_global_header_none(self, message):
-        """Handle global header message with details flag set to None.
-
-        :param message: The message received
-        """
-        self._logger.debug('Handling global header none for acqID ' + self._acquisition_id)
-        self._logger.debug(message)
-
-        if self._series_created:
-            self._logger.debug('series already created')
-            return
-
-        if not self.file_created:
-            self.create_file()
-
-        npa = np.array(message['series'])
-        self.create_dataset_with_data("series", data=npa)
-        self._series_created = True
-
-        return
-
-    def handle_global_header_config(self, header, config):
-        """Handle global header config part message containing config data.
-
-        :param header: The header received
-        :param config: The config data
-        """
-        self._logger.debug('Handling global header cfg for acqID ' + self._acquisition_id)
-        self._logger.debug(header)
-        self._logger.debug(config)
-
-        if not self.file_created:
-            self.create_file()
-
-        if self._config_created:
-            self._logger.debug('config already created')
+        handler = message_handlers.get(header[MESSAGE_TYPE_ID], None)
+        if handler is not None:
+            handler(header["header"], data)
         else:
-            nps = np.str(config)
-            config_data = ast.literal_eval(np.str(config).decode("utf-8"))
-            self.create_dataset_with_data("config", data=nps)
-            for k in sorted(config_data):
-                self.create_dataset_with_data("_dectris/%s" %k, config_data[k])
-            self._config_created = True
+            self._logger.debug(
+                "%s | Passing message %s to base class",
+                self._name,
+                header[MESSAGE_TYPE_ID],
+            )
+            super(EigerMetaWriter, self).process_message(header, data)
 
-        if self._series_created:
-            self._logger.debug('series already created')
-        else:
-            npa = np.array(header['series'])
-            self.create_dataset_with_data("series", data=npa)
-            self._series_created = True
+    def handle_global_header_none(self, _header, data):
+        """Handle global header message (header_detail = none)"""
+        self._logger.debug("%s | Handling global header none message", self._name)
 
-        return
+        self._add_dataset(SERIES, np.array(data[SERIES]))
 
-    def handle_flatfield_header(self, header, flatfield):
-        """Handle global header flatfield part message containing flatfield data.
+    def handle_global_header_config(self, _header, data):
+        """Handle global header config part message containing config data"""
+        self._logger.debug("%s | Handling global header config message", self._name)
 
-        :param header: The header received
-        :param flatfield: The flatfield data
-        """
-        self._logger.debug('Handling flatfield header for acqID ' + self._acquisition_id)
-        self._logger.debug(header)
+        self._add_dataset("config", data=str(data))
+        for parameter, value in data.items():
+            self._add_dataset("_dectris/{}".format(parameter), value)
 
-        if self._flatfield_created:
-            self._logger.debug('flatfield already created')
-            return
+    def handle_flatfield_header(self, _header, flatfield_blob):
+        """Handle global header flatfield part message containing flatfield array"""
+        self._logger.debug("%s | Handling flatfield header message", self._name)
 
-        if not self.file_created:
-            self.create_file()
+        flatfield_array = np.frombuffer(flatfield_blob, dtype=np.float32)
+        self._add_dataset("flatfield", flatfield_array)
 
-        self._flatfield_created = True
-        npa = np.frombuffer(flatfield, dtype=np.float32)
-        shape = header['shape']
-        self.create_dataset_with_data("flatfield", data=npa, shape=(shape[1], shape[0]))
-        return
+    def handle_mask_header(self, _header, mask_blob):
+        """Handle global header mask part message containing mask array"""
+        self._logger.debug("%s | Handling mask header message", self._name)
 
-    def handle_mask_header(self, header, mask):
-        """Handle global header pixel mask part message containing pixel mask data.
+        mask_array = np.frombuffer(mask_blob, dtype=np.uint32)
+        self._add_dataset("mask", mask_array)
 
-        :param header: The header received
-        :param mask: The pixel mask data
-        """
-        self._logger.debug('Handling mask header for acqID ' + self._acquisition_id)
-        self._logger.debug(header)
+    def handle_countrate_header(self, _header, countrate_blob):
+        """Handle global header mask part message containing mask array"""
+        self._logger.debug("%s | Handling countrate header message", self._name)
 
-        if self._pixel_mask_created:
-            self._logger.debug('pixel mask already created')
-            return
+        countrate_table = np.frombuffer(countrate_blob, dtype=np.float32)
+        self._add_dataset("countrate", countrate_table)
 
-        if not self.file_created:
-            self.create_file()
+    def handle_header_appendix(self, _header, data):
+        """Handle global header appendix part message"""
+        self._logger.debug("%s | Handling header appendix message", self._name)
 
-        self._pixel_mask_created = True
+        appendix = np.str(data)
+        self._add_dataset("global_appendix", appendix)
 
-        npa = np.frombuffer(mask, dtype=np.uint32)
-        shape = header['shape']
-        self.create_dataset_with_data("mask", data=npa, shape=(shape[1], shape[0]))
-        return
+    def handle_image_data(self, _header, data):
+        """Handle image data message"""
+        self._logger.debug("%s | Handling image data message", self._name)
 
-    def handle_countrate_header(self, header, countrate):
-        """Handle global header count rate part message containing count rate data.
+        # Store this to be written in write_detector_frame_data
+        # This will be called when handle_write_frame is called in the
+        # base class with this frame number
+        self._frame_data_map[data[FRAME]] = data
 
-        :param header: The header received
-        :param countrate: The count rate data
-        """
-        self._logger.debug('Handling countrate header for acqID ' + self._acquisition_id)
-        self._logger.debug(header)
-
-        if self._countrate_created:
-            self._logger.debug('countrate already created')
-            return
-
-        if not self.file_created:
-            self.create_file()
-
-        self._countrate_created = True
-
-        npa = np.frombuffer(countrate, dtype=np.float32)
-        shape = header['shape']
-        self.create_dataset_with_data("countrate", data=npa, shape=(shape[1], shape[0]))
-        return
-
-    def handle_global_header_appendix(self, appendix):
-        """Handle global header appendix part message.
-
-        :param appendix: The appendix data
-        """
-        self._logger.debug('Handling global header appendix for acqID ' + self._acquisition_id)
-
-        if self._global_appendix_created:
-            self._logger.debug('global appendix already created')
-            return
-
-        if not self.file_created:
-            self.create_file()
-
-        self._global_appendix_created = True
-
-        nps = np.str(appendix)
-        self.create_dataset_with_data("globalAppendix", data=nps)
-        return
-
-    def handle_data(self, header):
-        """Handle meta data message.
-
-        :param header: The header
-        """
-        frame_id = header['frame']
-
-        # Check if we know the offset to write to yet, if so write the frame, if not store the data until we do know.
-        if self._frame_offset_dict.has_key(frame_id) == True:
-            self.write_frame_data(self._frame_offset_dict[frame_id], header)
-            del self._frame_offset_dict[frame_id]
-            if self._close_after_write:
-                self.close_file()
-        else:
-            self._frame_data_dict[frame_id] = header
-
-        return
-
-    def handle_image_appendix(self, header, appendix):
-        """Handle meta data message appendix message part.
-
-        :param header: The header
-        :param appendix: The appendix data
-        """
-        self._logger.debug('Handling image appendix for acqID ' + self._acquisition_id)
-        self._logger.debug(header)
-        self._logger.debug(appendix)
+    def handle_image_appendix(self, _header, _data):
+        """Handle image appendix message"""
+        self._logger.debug("%s | Handling image appendix message", self._name)
         # Do nothing as can't write variable length dataset in swmr
-        return
 
-    def handle_end(self, message):
-        """Handle end of series message.
-
-        :param message: The message
-        """
-        self._logger.debug('Handling end for acqID ' + self._acquisition_id)
-        self._logger.debug(message)
+    def handle_end(self, _header, _data):
+        """Handle end message"""
+        self._logger.debug("%s | Handling end message", self._name)
         # Do nothing with end message
-        return
 
-    def handle_frame_writer_start_acquisition(self, userHeader):
-        """Handle frame writer plugin start acquisition message.
-
-        :param userHeader: The header
-        """
-        self._logger.debug('Handling frame writer start acquisition for acqID ' + self._acquisition_id)
-        self._logger.debug(userHeader)
-
-        self.number_processes_running = self.number_processes_running + 1
-
-        if not self.file_created:
-            self.create_file()
-
-        if self._num_frames_to_write == -1:
-            self._num_frames_to_write = userHeader['totalFrames']
-            self.create_arrays()
-
-        return
-
-    def handle_frame_writer_create_file(self, userHeader, fileName):
-        """Handle frame writer plugin create file message.
-
-        :param userHeader: The header
-        :param fileName: The file name
-        """
-        self._logger.debug('Handling frame writer create file for acqID ' + self._acquisition_id)
-        self._logger.debug(userHeader)
-        self._logger.debug(fileName)
-
-        return
-
-    def handle_frame_writer_write_frame(self, message):
-        """Handle frame writer plugin write frame message.
-
-        :param message: The message
-        """
-        frame_number = message['frame']
-        offset_value = message['offset']
-
-        if not self._arrays_created:
-            self._logger.error('Arrays not created, cannot handle frame writer data')
-            return
-
-        offset_to_write_to = offset_value
-
-        if self._num_frame_offsets_written + 1 > self._num_frames_to_write:
-            self._data_set_arrays["frame_written"] = np.resize(self._data_set_arrays["frame_written"],
-                                                               (self._num_frame_offsets_written + 1,))
-            self._data_set_arrays["offset_written"] = np.resize(self._data_set_arrays["offset_written"],
-                                                                (self._num_frame_offsets_written + 1,))
-
-        self._data_set_arrays["frame_written"][self._num_frame_offsets_written] = frame_number
-        self._data_set_arrays["offset_written"][self._num_frame_offsets_written] = offset_to_write_to
-
-        self._num_frame_offsets_written = self._num_frame_offsets_written + 1
-
-        # Check if we have the data and/or appendix for this frame yet. If so, write it in the offset given
-        if self._frame_data_dict.has_key(frame_number):
-            self.write_frame_data(offset_to_write_to, self._frame_data_dict[frame_number])
-            del self._frame_data_dict[frame_number]
-        else:
-            self._frame_offset_dict[frame_number] = offset_to_write_to
-
-        return
-
-    def create_arrays(self):
-        """Create the data set arrays for all of the Eiger meta datasets."""
-        self._data_set_arrays["start_time"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-        self._data_set_arrays["stop_time"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-        self._data_set_arrays["real_time"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-        self._data_set_arrays["frame"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-        self._data_set_arrays["size"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-        self._data_set_arrays["hash"] = np.empty(self._num_frames_to_write, dtype='S32')
-        self._data_set_arrays["encoding"] = np.empty(self._num_frames_to_write, dtype='S10')
-        self._data_set_arrays["datatype"] = np.empty(self._num_frames_to_write, dtype='S6')
-        self._data_set_arrays["frame_series"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-
-        self._data_set_arrays["frame_written"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-        self._data_set_arrays["offset_written"] = np.negative(np.ones((self._num_frames_to_write,), dtype=np.int64))
-
-        self._hdf5_datasets["start_time"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["stop_time"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["real_time"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["frame"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["size"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["hash"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["encoding"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["datatype"].resize(self._num_frames_to_write, axis=0)
-        self._hdf5_datasets["frame_series"].resize(self._num_frames_to_write, axis=0)
-
-        self._hdf5_file.swmr_mode = True
-
-        self._arrays_created = True
-
-    def handle_frame_writer_close_file(self):
-        """Handle frame writer plugin close file message."""
-        self._logger.debug('Handling frame writer close file for acqID ' + self._acquisition_id)
-        # Do nothing
-        return
-
-    def close_file(self):
-        """Close the file."""
-        if len(self._frame_offset_dict) > 0:
-            # Writers have finished but we haven't got all associated meta. Wait till it comes before closing
-            self._logger.info('Unable to close file as Frame Offset Dict Length = ' + str(len(self._frame_offset_dict)))
-            self._close_after_write = True
-            return
-
-        self.write_datasets()
-
-        if self._hdf5_file is not None:
-            self._logger.info('Closing file ' + self.full_file_name)
-            self._hdf5_file.close()
-            self._logger.info('Meta frames written: ' + str(self._current_frame_count) + ' of ' + str(self._num_frames_to_write))
-            self._hdf5_file = None
-
-        self.finished = True
-
-    def handle_frame_writer_stop_acquisition(self, userheader):
-        """Handle frame writer plugin stop acquisition message.
-
-        :param userheader: The user header
-        """
-        self._logger.debug('Handling frame writer stop acquisition for acqID ' + self._acquisition_id)
-        self._logger.debug(userheader)
-
-        if self.number_processes_running > 0:
-            self.number_processes_running = self.number_processes_running - 1
-
-        if self.number_processes_running == 0:
-            self._logger.info('Last processor ended for acqID ' + str(self._acquisition_id))
-            if self._current_frame_count >= self._num_frames_to_write:
-                self.close_file()
-            else:
-                self._logger.info(
-                    'Not closing file as not all frames written (' + str(self.write_count) + ' of ' + str(
-                        self._num_frames_to_write) + ')')
-        else:
-            self._logger.info('Processor ended, but not the last for acqID ' + str(self._acquisition_id))
-
-        return
-
-    def write_frame_data(self, offset, header):
-        """Write the frame data to the arrays and flush if necessary.
-
-        :param offset: The offset to write to in the arrays
-        :param header: The data header
-        """
-        if not self._arrays_created:
-            self._logger.error('Arrays not created, cannot write frame data')
-            return
-
-        if offset + 1 > self._current_frame_count:
-            self._current_frame_count = offset + 1
-
-        self._data_set_arrays["start_time"][offset] = header['start_time']
-        self._data_set_arrays["stop_time"][offset] = header['stop_time']
-        self._data_set_arrays["real_time"][offset] = header['real_time']
-        self._data_set_arrays["frame"][offset] = header['frame']
-        self._data_set_arrays["size"][offset] = header['size']
-        self._data_set_arrays["hash"][offset] = header['hash']
-        self._data_set_arrays["encoding"][offset] = header['encoding']
-        self._data_set_arrays["datatype"][offset] = header['type']
-        self._data_set_arrays["frame_series"][offset] = header['series']
-
-        self.write_count = self.write_count + 1
-        self._need_to_write_data = True
-
-        flush = False
-        if self.flush_timeout is not None:
-            if (time.time() - self._last_flushed) >= self.flush_timeout:
-                flush = True
-        elif (self.write_count % self.flush_frequency) == 0:
-            flush = True
-
-        if flush:
-            self.write_datasets()
-
-        # Reset timeout count to 0
-        self.write_timeout_count = 0
-
-        return
-
-    def write_datasets(self):
-        """Write the datasets to the hdf5 file."""
-        if not self._arrays_created:
-            self._logger.warn('Arrays not created, cannot write datasets from frame data')
-            return
-
-        if self._need_to_write_data:
-            self._logger.info('Writing data to datasets at write count ' + str(self.write_count) + ' for acqID ' + str(self._acquisition_id))
-            self._hdf5_datasets["start_time"][0:self._num_frames_to_write] = self._data_set_arrays["start_time"]
-            self._hdf5_datasets["stop_time"][0:self._num_frames_to_write] = self._data_set_arrays["stop_time"]
-            self._hdf5_datasets["real_time"][0:self._num_frames_to_write] = self._data_set_arrays["real_time"]
-            self._hdf5_datasets["frame"][0:self._num_frames_to_write] = self._data_set_arrays["frame"]
-            self._hdf5_datasets["size"][0:self._num_frames_to_write] = self._data_set_arrays["size"]
-            self._hdf5_datasets["hash"][0:self._num_frames_to_write] = self._data_set_arrays["hash"]
-            self._hdf5_datasets["encoding"][0:self._num_frames_to_write] = self._data_set_arrays["encoding"]
-            self._hdf5_datasets["datatype"][0:self._num_frames_to_write] = self._data_set_arrays["datatype"]
-            self._hdf5_datasets["frame_series"][0:self._num_frames_to_write] = self._data_set_arrays["frame_series"]
-
-            self._hdf5_datasets["frame_written"].resize(self._num_frame_offsets_written, axis=0)
-            self._hdf5_datasets["frame_written"][0:self._num_frame_offsets_written] = self._data_set_arrays["frame_written"][0:self._num_frame_offsets_written]
-
-            self._hdf5_datasets["offset_written"].resize(self._num_frame_offsets_written, axis=0)
-            self._hdf5_datasets["offset_written"][0:self._num_frame_offsets_written] = self._data_set_arrays["offset_written"][0:self._num_frame_offsets_written]
-
-            self._hdf5_datasets["start_time"].flush()
-            self._hdf5_datasets["stop_time"].flush()
-            self._hdf5_datasets["real_time"].flush()
-            self._hdf5_datasets["frame"].flush()
-            self._hdf5_datasets["size"].flush()
-            self._hdf5_datasets["hash"].flush()
-            self._hdf5_datasets["encoding"].flush()
-            self._hdf5_datasets["datatype"].flush()
-            self._hdf5_datasets["frame_series"].flush()
-            self._hdf5_datasets["frame_written"].flush()
-            self._hdf5_datasets["offset_written"].flush()
-
-            self._last_flushed = time.time()
-
-            self._need_to_write_data = False
-
-    def stop(self):
-        """Stop this acquisition."""
-        self._frame_offset_dict.clear()
-        self.close_file()
-
-    def process_message(self, message, userheader, receiver):
-        """Process a meta message.
-
-        :param message: The message
-        :param userheader: The user header
-        :param receiver: The ZeroMQ socket the data was received on
-        """
-        self._logger.debug('Eiger Meta Writer Handling message')
-
-        if message['parameter'] == "eiger-globalnone":
-            receiver.recv_json()
-            self.handle_global_header_none(message)
-        elif message['parameter'] == "eiger-globalconfig":
-            config = receiver.recv_json()
-            self.handle_global_header_config(userheader, config)
-        elif message['parameter'] == "eiger-globalflatfield":
-            flatfield = receiver.recv()
-            self.handle_flatfield_header(userheader, flatfield)
-        elif message['parameter'] == "eiger-globalmask":
-            mask = receiver.recv()
-            self.handle_mask_header(userheader, mask)
-        elif message['parameter'] == "eiger-globalcountrate":
-            countrate = receiver.recv()
-            self.handle_countrate_header(userheader, countrate)
-        elif message['parameter'] == "eiger-headerappendix":
-            appendix = receiver.recv()
-            self.handle_global_header_appendix(appendix)
-        elif message['parameter'] == "eiger-imagedata":
-            imageMetaData = receiver.recv_json()
-            self.handle_data(imageMetaData)
-        elif message['parameter'] == "eiger-imageappendix":
-            appendix = receiver.recv()
-            self.handle_image_appendix(userheader, appendix)
-        elif message['parameter'] == "eiger-end":
-            receiver.recv()
-            self.handle_end(message)
-        elif message['parameter'] == "createfile":
-            fileName = receiver.recv()
-            self.handle_frame_writer_create_file(userheader, fileName)
-        elif message['parameter'] == "closefile":
-            receiver.recv()
-            self.handle_frame_writer_close_file()
-        elif message['parameter'] == "startacquisition":
-            receiver.recv()
-            self.handle_frame_writer_start_acquisition(userheader)
-        elif message['parameter'] == "stopacquisition":
-            receiver.recv()
-            self.handle_frame_writer_stop_acquisition(userheader)
-        elif message['parameter'] == "writeframe":
-            value = receiver.recv_json()
-            self.handle_frame_writer_write_frame(value)
-        else:
-            self._logger.error('unknown parameter: ' + str(message))
-            value = receiver.recv()
-            self._logger.error('value: ' + str(value))
-
-        return
+    @staticmethod
+    def get_version():
+        return construct_version_dict(versioneer.get_versions()["version"])

--- a/data/tools/python/metalistener/eiger_meta_writer.py
+++ b/data/tools/python/metalistener/eiger_meta_writer.py
@@ -51,13 +51,11 @@ class EigerMetaWriter(MetaWriter):
         DATATYPE,
     ]
 
-    def process_message(self, header, data):
-        """Process a message from a data socket
 
-        Check for Eiger-specific messages and pass anything else to base class
 
-        """
-        message_handlers = {
+    @property
+    def detector_message_handlers(self):
+        return {
             "eiger-globalnone": self.handle_global_header_none,
             "eiger-globalconfig": self.handle_global_header_config,
             "eiger-globalflatfield": self.handle_flatfield_header,
@@ -68,17 +66,6 @@ class EigerMetaWriter(MetaWriter):
             "eiger-imageappendix": self.handle_image_appendix,
             "eiger-end": self.handle_end,
         }
-
-        handler = message_handlers.get(header[MESSAGE_TYPE_ID], None)
-        if handler is not None:
-            handler(header["header"], data)
-        else:
-            self._logger.debug(
-                "%s | Passing message %s to base class",
-                self._name,
-                header[MESSAGE_TYPE_ID],
-            )
-            super(EigerMetaWriter, self).process_message(header, data)
 
     def handle_global_header_none(self, _header, data):
         """Handle global header message (header_detail = none)"""

--- a/data/tools/python/metalistener/eiger_meta_writer.py
+++ b/data/tools/python/metalistener/eiger_meta_writer.py
@@ -230,16 +230,16 @@ class EigerMetaWriter(MetaWriter):
             "eiger-end": self.handle_end,
         }
 
-        """Handle global header message (header_detail = none)"""
     def handle_global_header_none(self, header, _data):
+        """Handle global header message part 1"""
         self._logger.debug("%s | Handling global header none message", self._name)
 
         # Register the series we are expecting in proceding messages
         self._series = header[SERIES]
         self._write_dataset(SERIES, header[SERIES])
 
-        """Handle global header config part message containing config data"""
     def handle_global_header_config(self, header, data):
+        """Handle global header message part (1 and) 2 containing config data"""
         self._logger.debug("%s | Handling global header config message", self._name)
 
         self.handle_global_header_none(header, data)
@@ -289,7 +289,7 @@ class EigerMetaWriter(MetaWriter):
         self._add_dataset("global_appendix", appendix)
 
     def handle_image_data(self, header, data):
-        """Handle image data message"""
+        """Handle image data message parts 1, 2 and 4"""
         self._logger.debug("%s | Handling image data message", self._name)
 
         if self._series_valid(header):

--- a/data/tools/python/metalistener/eiger_meta_writer.py
+++ b/data/tools/python/metalistener/eiger_meta_writer.py
@@ -51,7 +51,9 @@ class EigerMetaWriter(MetaWriter):
         DATATYPE,
     ]
 
-
+    def __init__(self, *args, **kwargs):
+        super(EigerMetaWriter, self).__init__(*args, **kwargs)
+        self._detector_finished = False  # Require base class to check we have finished
 
     @property
     def detector_message_handlers(self):
@@ -124,9 +126,9 @@ class EigerMetaWriter(MetaWriter):
         # Do nothing as can't write variable length dataset in swmr
 
     def handle_end(self, _header, _data):
-        """Handle end message"""
+        """Handle end message - register to stop when writers finished"""
         self._logger.debug("%s | Handling end message", self._name)
-        # Do nothing with end message
+        self.stop_when_writers_finished()
 
     @staticmethod
     def get_version():

--- a/data/tools/python/requirements.txt
+++ b/data/tools/python/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.13.1
+numpy>=1.13.1
 pyzmq==17.1.0
 h5py==2.9.0
 odin-data>=1-3-1


### PR DESCRIPTION
This moves most of the functionality out of the EigerMetaWriter into the base class so that it can be shared with other detectors.

The functionality should be basically the same. Differences I am aware of:
- The datatype `dataset` has be renamed to `type` because that is what the message parameter is called in the SIMPLON API

odin-data PR here: https://github.com/odin-detector/odin-data/pull/242