### PR TITLE
Add declaration for DETECTOR_MODEL_1M

### DIFF
--- a/cpp/data/frameReceiver/include/EigerFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/EigerFrameDecoder.h
@@ -87,6 +87,7 @@ namespace FrameReceiver
 
     static const std::string CONFIG_DETECTOR_MODEL;
     static const std::string DETECTOR_MODEL_500K;
+    static const std::string DETECTOR_MODEL_1M;
     static const std::string DETECTOR_MODEL_4M;
     static const std::string DETECTOR_MODEL_9M;
     static const std::string DETECTOR_MODEL_16M;


### PR DESCRIPTION
Missed this change out somehow, should fix latest merge which breaks the build