### PR TITLE
Add Fan /dev/shm cache

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -5,6 +5,10 @@ set(SOURCE_DIR ${EigerDetector_SOURCE_DIR})
 # Require CMake version >=2.8
 cmake_minimum_required(VERSION 2.8)
 
+# Set C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set output directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -14,10 +18,12 @@ set(CMAKE_CONFIG_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test_config)
 # directories of additional CMake modules (ie. MacroOutOfSourceBuild.cmake):
 set(CMAKE_MODULE_PATH ${SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 # Find and add external packages required for application and test
 find_package(
     Boost 1.41.0 REQUIRED
-    COMPONENTS program_options system unit_test_framework date_time thread
+    COMPONENTS program_options system filesystem unit_test_framework date_time thread
 )
 find_package(LOG4CXX 0.10.0 REQUIRED)
 find_package(ZEROMQ 3.2.4 REQUIRED)

--- a/cpp/data/common/include/EigerDefinitions.h
+++ b/cpp/data/common/include/EigerDefinitions.h
@@ -59,6 +59,7 @@ namespace Eiger {
   const std::string CONTROL_OFFSET = "offset";
   const std::string CONTROL_ACQ_ID = "acqid";
   const std::string CONTROL_FWD_STREAM = "forward_stream";
+  const std::string CONTROL_DEV_SHM_CACHE = "dev_shm_cache";
   const std::string CONTROL_BLOCK_SIZE = "block_size";
 
   const std::string CONTROL_RESPONSE_OK = "{\"msg_type\":\"ack\",\"msg_val\":\"configure\", \"params\": {}}";
@@ -74,6 +75,8 @@ namespace Eiger {
   static const std::string STATE_DSTR_IMAGE = "DSTR_IMAGE";
   static const std::string STATE_DSTR_END = "DSTR_END";
   static const std::string STATE_KILL_REQUESTED = "KILL_REQUESTED";
+
+  static const std::string DEV_SHM_PATH = "/dev/shm/eiger";
 
   enum EigerMessageType { GLOBAL_HEADER_NONE, GLOBAL_HEADER_CONFIG, GLOBAL_HEADER_FLATFIELD, GLOBAL_HEADER_MASK, GLOBAL_HEADER_COUNTRATE, GLOBAL_HEADER_APPENDIX, IMAGE_DATA, IMAGE_APPENDIX, END_OF_STREAM};
 

--- a/cpp/data/eigerfan/include/EigerFan.h
+++ b/cpp/data/eigerfan/include/EigerFan.h
@@ -36,8 +36,9 @@ public:
 protected:
   void HandleStreamMessage(zmq::message_t &message, boost::shared_ptr<zmq::socket_t> socket);
   void HandleGlobalHeaderMessage(boost::shared_ptr<zmq::socket_t> socket);
-  void HandleImageDataMessage(boost::shared_ptr<zmq::socket_t> socket);
+  void HandleImageDataMessage(boost::shared_ptr<zmq::socket_t> socket, uint64_t frame_number);
   void HandleEndOfSeriesMessage(boost::shared_ptr<zmq::socket_t> socket);
+  void WriteMessageToFile(zmq::message_t &message, std::string filename);
   void HandleMonitorMessage(zmq::message_t &message, boost::shared_ptr<zmq::socket_t> socket, int rank);
   void HandleForwardMonitorMessage(zmq::message_t &message, zmq::socket_t &socket);
   void HandleControlMessage(zmq::message_t &message, zmq::message_t &idMessage);
@@ -71,6 +72,7 @@ private:
   int currentOffset;
   int numConnectedForwardingSockets;
   bool forwardStream;
+  bool devShmCache;
 };
 
 


### PR DESCRIPTION
This adds the option to write all eiger stream messages to a cache in /dev/shm/eiger for local processing.

When enabled it is expected that the files will be processed and then deleted, otherwise memory will be exhausted and further writes to the cache will fail. The files in the cache will be cleared when it is disabled.